### PR TITLE
remove private accesor to avoid error

### DIFF
--- a/projects/ngx-date-picker/src/ngx-date-picker.directive.ts
+++ b/projects/ngx-date-picker/src/ngx-date-picker.directive.ts
@@ -16,7 +16,7 @@ export class NgxDatePickerDirective implements OnInit, AfterViewInit, OnDestroy,
 
     onChangeSubscription: Subscription;
 
-    @Input('ngxDatePicker') private datePickerInstance: NgxDatePickerComponent;
+    @Input('ngxDatePicker') datePickerInstance: NgxDatePickerComponent;
 
     @Input() value: Date | DateRange;
     @Output() valueChange: EventEmitter<Date | DateRange> = new EventEmitter();


### PR DESCRIPTION
present error in angular 11 in AOT compilation
Property 'datePickerInstance' is private and only accessible within class 'NgxDatePickerDirective'.